### PR TITLE
fix of overlap

### DIFF
--- a/dcmweb/dcmweb.py
+++ b/dcmweb/dcmweb.py
@@ -35,6 +35,7 @@ def execute_file_transfer_futures(futures_arguments, multithreading):
                 running_futures, transferred, QUEUE_LIMIT)
             running_futures.add(executor.submit(*future_arguments))
         wait_for_futures_limit(running_futures, transferred, 0)
+    logging.info('')#new line to avoid overlap by next output
     return transferred
 
 


### PR DESCRIPTION
[#5] in case if update of status line is finished, new output may overlap it, to avoid it print if empty string is added