### PR TITLE
google.auth is replaced with google-auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
 
     install_requires=[
         'fire',
-        'google.auth',
+        'google-auth',
         'requests',
         'validators',
         'requests_toolbelt',


### PR DESCRIPTION
[#14] , because of different behavior in some systems
**google.auth and google-auth works on:** fedora, ubuntu
**only google.auth works on:** centos, debian