### PR TITLE
[#51] v1 api updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DICOMweb command line tool is a command line utility for interacting with DICOMw
 ### Using GitHub:
 
 ```bash
-pip install https://github.com/GoogleCloudPlatform/healthcare-api-dicomweb-cli/archive/v1.0.1.zip
+pip install https://github.com/GoogleCloudPlatform/healthcare-api-dicomweb-cli/archive/v1.0.2.zip
 ```
 
 NOTE: Getting errors due to not having Python3? See [instructions below](#running-on-machine-with-python2).
@@ -26,7 +26,7 @@ NOTE: Getting errors due to not having Python3? See [instructions below](#runnin
 
 * **host**
 \
- The full DICOMweb endpoint URL. E.g. `https://healthcare.googleapis.com/v1beta1/projects/<project_id>/locations/<location_id>/datasets/<dataset_id>/dicomStores/<dicom_store_id>/dicomWeb`
+ The full DICOMweb endpoint URL. E.g. `https://healthcare.googleapis.com/v1/projects/<project_id>/locations/<location_id>/datasets/<dataset_id>/dicomStores/<dicom_store_id>/dicomWeb`
 
 * **store**
 \

--- a/cloudBuild/cloudbuild.yaml
+++ b/cloudBuild/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
   - '${_DATASET}'
   
 substitutions:
-  _STAGE: v1beta1
+  _STAGE: v1
   _PROJECT: gcp-healthcare-oss-test
   _LOCATION: us-central1
   _DATASET: healthcare-api-dicomweb-cli-test

--- a/cloudBuild/integrationTests.sh
+++ b/cloudBuild/integrationTests.sh
@@ -62,9 +62,16 @@ dcmweb $host retrieve studies/111/series/111/instances/111
 retrieve_exit_code=$?
 
 dcmweb $host delete studies/111/series/111/instances/111
-delete_exit_code=$?
+delete_instance_exit_code=$?
 
-dcmweb $host search studies > ./cloudBuild/searchResultsAfterDelete.json
+dcmweb $host search studies > ./cloudBuild/searchResultsAfterInstanceDelete.json
+
+dcmweb $host store ./cloudBuild/dcms/1.dcm
+dcmweb $host delete studies/111
+delete_study_exit_code=$?
+
+dcmweb $host search studies > ./cloudBuild/searchResultsAfterStudyDelete.json
+
 
 gcloud beta healthcare dicom-stores delete "${dicom_store_name}" \
   --location=$LOCATION \
@@ -73,10 +80,12 @@ gcloud beta healthcare dicom-stores delete "${dicom_store_name}" \
 
 compare_files ./cloudBuild/searchResults.json ./cloudBuild/expectedSearchResults.json
 compare_files ./111/111/111.dcm ./cloudBuild/dcms/1.dcm
-compare_files ./cloudBuild/searchResultsAfterDelete.json ./cloudBuild/expectedSearchResultsAfterDelete.json
+compare_files ./cloudBuild/searchResultsAfterInstanceDelete.json ./cloudBuild/expectedSearchResultsAfterDelete.json
+compare_files ./cloudBuild/searchResultsAfterStudyDelete.json ./cloudBuild/expectedSearchResultsAfterDelete.json
 
 
 check_exit_code $single_upload_exit_code "single upload failed"
 check_exit_code $search_exit_code "search failed"
 check_exit_code $retrieve_exit_code "retrieve failed"
-check_exit_code $delete_exit_code "delete failed"
+check_exit_code $delete_instance_exit_code "instance delete failed"
+check_exit_code $delete_study_exit_code "study delete failed"

--- a/cloudBuild/pylint.sh
+++ b/cloudBuild/pylint.sh
@@ -20,7 +20,7 @@ checkFolder () {
   fi
 }
 
-pip3 install pylint 
+pip3 install pylint==2.4.4 
 pip3 install -r requirements.txt
 
 checkFolder ./dcmweb

--- a/cloudBuild/runTestsAndBuild.sh
+++ b/cloudBuild/runTestsAndBuild.sh
@@ -15,7 +15,7 @@
 apt-get update
 apt-get -qq install python3.7 -y 
 
-pip3 install tox wheel
+pip3 install tox==3.14.5 wheel
 pip3 install -r requirements.txt
 tox
 test_result=$?

--- a/dcmweb/command_line.py
+++ b/dcmweb/command_line.py
@@ -14,7 +14,7 @@ dcmweb [-m] <host> <store|retrieve|search|delete> [parameters]\n\
 Whether to perform batch operations in parallel or sequentially, default is in sequentially\n\
 \n\
     host  \n\
-The full DICOMweb endpoint URL. E.g. `https://healthcare.googleapis.com/v1beta1/projects/<project_id>/\
+The full DICOMweb endpoint URL. E.g. `https://healthcare.googleapis.com/v1/projects/<project_id>/\
 locations/<location_id>/datasets/<dataset_id>/dicomStores/<dicom_store_id>/dicomWeb`\n\
 \n\
     store  \n\

--- a/dcmweb/requests_util.py
+++ b/dcmweb/requests_util.py
@@ -160,6 +160,7 @@ class Requests:
         if response.status_code != 200:
             raise NetworkError("sending http delete request: {}\n response: {}".format(
                 path, resources.pretty_format(response.text, response.headers[CONTENT_TYPE])))
+        return response.text
 
     def search_instances_by_page(self, ids, parameters, page):
         """Performs page request"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pytest
-fire
-google.auth
-requests
-validators
-httpretty
-pytest-check
-hurry.filesize
+pytest==5.4.1
+fire==0.3.1
+google.auth==1.11.3
+requests==2.23.0
+validators==0.15.0
+httpretty==0.9.7
+pytest-check==0.3.7
+hurry.filesize==0.9

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
 
     name='dcmweb',
 
-    version='1.0.1',
+    version='1.0.2',
 
     author="Google",
 

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Delete method tests
+"""
+import json
+import random
+import httpretty
+from dcmweb import dcmweb
+
+
+@httpretty.activate
+def test_delete():
+    """delete request should be performed in old and new api"""
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://dicom.com/v1/dicomWeb/studies?limit=1",
+        match_querystring=True
+    )
+    dcmweb_cli = dcmweb.Dcmweb("https://dicom.com/v1/dicomWeb/", False, None)
+    empty_response = DeleteResponse('{}')
+
+    httpretty.register_uri(
+        httpretty.DELETE,
+        "https://dicom.com/v1/dicomWeb/studies/1",
+        status=200,
+        match_querystring=True,
+        body=empty_response.request_callback
+    )
+    dcmweb_cli.delete("studies/1")
+
+    assert empty_response.requested
+
+    operation_response = DeleteResponse('{"name":"/operation/1"}')
+    operation_progress = OperationProgress()
+
+    httpretty.register_uri(
+        httpretty.DELETE,
+        "https://dicom.com/v1/dicomWeb/studies/2",
+        status=200,
+        match_querystring=True,
+        body=operation_response.request_callback
+    )
+
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://dicom.com/v1/operation/1",
+        status=200,
+        match_querystring=True,
+        body=operation_progress.request_callback
+    )
+
+    dcmweb_cli.delete("studies/2")
+
+    assert operation_progress.requests < 1
+    assert operation_response.requested
+
+    operation_response = DeleteResponse('{"name":"/operation/2"}')
+    httpretty.register_uri(
+        httpretty.DELETE,
+        "https://dicom.com/v1/dicomWeb/studies/3",
+        status=200,
+        match_querystring=True,
+        body=operation_response.request_callback
+    )
+
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://dicom.com/v1/operation/2",
+        status=404,
+        match_querystring=True,
+    )
+
+    assert dcmweb_cli.delete("studies/3") == "/operation/2"
+
+
+class OperationProgress: # pylint: disable=too-few-public-methods; disabled because this is simple class for request callback
+    """Counts random amount of requests"""
+
+    def __init__(self):
+        self.requests = random.randint(1, 5)
+
+    def request_callback(self, request, uri, response_headers): # pylint: disable=unused-argument
+        """Counts requests and returns json based on it"""
+        self.requests -= 1
+        return [200, response_headers, json.dumps({"done":self.requests < 1})]
+
+class DeleteResponse: # pylint: disable=too-few-public-methods; disabled because this is simple class for request callback
+    """Returns body and keep flag"""
+
+    def __init__(self, data):
+        self.data = data
+        self.requested = False
+
+    def request_callback(self, request, uri, response_headers): # pylint: disable=unused-argument
+        """Returns body and sets flag"""
+        self.requested = True
+        return [200, response_headers, self.data]


### PR DESCRIPTION
this PR contains:
- "v1beta1"->"v1" in readme and integration tests
- all dependencies set to static versions to avoid breaking changes, httpretty updated after previous PR and now have a bit different way to specify binary data in mock uri, i think such updates should be done in separated PRs and if required 
- delete request now handles operation polling, and return operation name if operation is not reachable 